### PR TITLE
Non x86-64 architecture build issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,5 +30,5 @@ RUN setcap 'cap_sys_nice=eip' /home/hercules/herctest/herc4x/bin/hercules && \
     setcap 'cap_sys_nice=eip' /home/hercules/herctest/herc4x/bin/herclin && \
     setcap 'cap_net_admin+ep' /home/hercules/herctest/herc4x/bin/hercifc && \
     chown hercules:hercules /home/hercules/herctest/herc4x/bin/hercules && \
-    ln -s /usr/lib/x86_64-linux-gnu/libregina.so.3 /usr/lib/x86_64-linux-gnu/libregina.so
+    ln -s /usr/lib/$(uname -m)-linux-gnu/libregina.so.3 /usr/lib/$(uname -m)-linux-gnu/libregina.so
 USER hercules

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Create a docker container of the newest hercules from source
 
 ## Build container
 
-`docker build --tag "mainframed767/hercules:latest" .`
+`docker build --tag "m3-repos/hercules:latest" .`
 
 ## Run container 
 
-`docker run -it -u root -p 3270:3270 -p 8038:8038 -v $(pwd)/MAINFRAME:/home/hercules/MAINFRAME mainframed767/hercules:latest`
+`docker run -it -u root -p 3270:3270 -p 8038:8038 -v $(pwd)/MAINFRAME:/home/hercules/MAINFRAME m3-repos/hercules:latest`
 
 *MAINFRAME directory contains essential mainframe image, config and other files`


### PR DESCRIPTION
Symbolic link was hard coded for x86_64 causing container build to fail on other architectures.